### PR TITLE
Fix: Remove classe stretched-link

### DIFF
--- a/scheduler/templates/scheduler/partials/calendario_content.html
+++ b/scheduler/templates/scheduler/partials/calendario_content.html
@@ -144,7 +144,7 @@
         color: inherit;
         text-decoration: none;
     }
-    
+
     .card-title-agenda a:hover {
         text-decoration: underline;
     }
@@ -383,7 +383,7 @@
                             {# CORPO: Título (Aluno/Atividade) e Subtítulo (Modalidade) #}
                             <div>
                                 <h6 class="card-title-agenda">
-                                    <a href="{% if aula.status == 'Agendada' %}{% url 'scheduler:aula_editar' aula.pk %}{% else %}{% url 'scheduler:aula_validar' aula.pk %}{% endif %}" class="stretched-link">
+                                    <a href="{% if aula.status == 'Agendada' %}{% url 'scheduler:aula_editar' aula.pk %}{% else %}{% url 'scheduler:aula_validar' aula.pk %}{% endif %}">
                                         {% if "atividade complementar" in aula.modalidade.nome|lower %}
                                             {{ aula.modalidade.nome }}
                                         {% else %}


### PR DESCRIPTION
**Qual era o problema?**

No último merge, uma classe `.stretched-link` foi aplicada indevidamente a um contêiner no calendário da dashboard. Isso fazia com que uma área clicável invisível cobrisse toda a lista de aulas, impedindo a interação com outros botões (como o menu de 3 pontos).

**O que este PR faz?**

* Remove a classe `.stretched-link` do contêiner geral do card de aula.
* Restaura o comportamento esperado, onde apenas os links e botões específicos dentro dos cards são clicáveis.

Esta correção resolve o bug visual e restaura a usabilidade do calendário no desktop.